### PR TITLE
Implement mobile-first visual novel UI and engine

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,191 +2,437 @@
 <html lang="ru">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-    <meta name="mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-    <title>City Chaos - GTA 2 Style Game</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="theme-color" content="#0d0d1a">
+    <title>Тихие встречи — визуальная новелла</title>
     <style>
+        :root {
+            color-scheme: dark;
+            --bg: #0d0d1a;
+            --bg-soft: #141428;
+            --accent: #ff7aa2;
+            --accent-2: #7ad7ff;
+            --text: #f5f2ff;
+            --muted: #b8b3d9;
+            --glass: rgba(255, 255, 255, 0.08);
+            --glass-strong: rgba(255, 255, 255, 0.16);
+            --success: #93f7c0;
+            --danger: #ff9aa2;
+            font-synthesis: none;
+            text-rendering: optimizeLegibility;
+        }
+
         * {
             margin: 0;
             padding: 0;
             box-sizing: border-box;
         }
-        
+
         body {
-            background: #000;
-            overflow: hidden;
-            touch-action: none;
-            user-select: none;
-            -webkit-user-select: none;
-            -webkit-touch-callout: none;
-            -webkit-tap-highlight-color: transparent;
+            min-height: 100vh;
+            font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+            background: radial-gradient(circle at top, #1a1233, #080810 60%);
+            color: var(--text);
+            overflow-x: hidden;
         }
-        
-        #game-container {
+
+        .app {
+            display: grid;
+            grid-template-rows: auto 1fr auto;
+            min-height: 100vh;
+            padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+        }
+
+        header {
             display: flex;
-            justify-content: center;
+            justify-content: space-between;
             align-items: center;
-            width: 100vw;
-            height: 100vh;
+            padding: 20px clamp(16px, 4vw, 40px);
+        }
+
+        .title {
+            font-size: clamp(20px, 4vw, 32px);
+            font-weight: 700;
+            letter-spacing: 0.04em;
+        }
+
+        .subtitle {
+            font-size: clamp(12px, 2.4vw, 14px);
+            color: var(--muted);
+        }
+
+        .status-panel {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+            justify-content: flex-end;
+        }
+
+        .pill {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            padding: 8px 12px;
+            border-radius: 999px;
+            background: var(--glass);
+            font-size: 12px;
+            color: var(--muted);
+            border: 1px solid transparent;
+        }
+
+        .pill strong {
+            color: var(--text);
+            font-weight: 600;
+        }
+
+        main {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) minmax(240px, 320px);
+            gap: clamp(16px, 3vw, 32px);
+            padding: 0 clamp(16px, 4vw, 40px) 24px;
+        }
+
+        .scene {
+            background: linear-gradient(145deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 24px;
+            padding: clamp(16px, 3vw, 28px);
+            box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
             position: relative;
+            overflow: hidden;
         }
-        
-        #game-canvas {
-            display: block;
-            image-rendering: pixelated;
-            image-rendering: -moz-crisp-edges;
-            image-rendering: crisp-edges;
-        }
-        
-        #mobile-controls {
-            position: fixed;
-            bottom: 20px;
-            left: 0;
-            right: 0;
-            display: none;
-            z-index: 1000;
-            pointer-events: none;
-        }
-        
-        .control-button {
+
+        .scene::before,
+        .scene::after {
+            content: "";
             position: absolute;
-            width: 60px;
-            height: 60px;
-            background: rgba(255, 255, 255, 0.3);
-            border: 2px solid rgba(255, 255, 255, 0.5);
+            width: 220px;
+            height: 220px;
             border-radius: 50%;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            font-size: 24px;
-            color: white;
-            pointer-events: auto;
-            touch-action: none;
-            user-select: none;
+            filter: blur(60px);
+            opacity: 0.4;
+            z-index: 0;
         }
-        
-        .control-button:active {
-            background: rgba(255, 255, 255, 0.5);
+
+        .scene::before {
+            background: var(--accent);
+            top: -80px;
+            right: -60px;
         }
-        
-        #joystick-container {
-            position: absolute;
-            left: 30px;
-            bottom: 30px;
-            width: 150px;
-            height: 150px;
-            pointer-events: auto;
+
+        .scene::after {
+            background: var(--accent-2);
+            bottom: -80px;
+            left: -60px;
         }
-        
-        #joystick-base {
-            position: absolute;
-            width: 150px;
-            height: 150px;
-            background: rgba(255, 255, 255, 0.2);
-            border: 3px solid rgba(255, 255, 255, 0.4);
-            border-radius: 50%;
-        }
-        
-        #joystick-stick {
-            position: absolute;
-            width: 60px;
-            height: 60px;
-            background: rgba(255, 255, 255, 0.5);
-            border: 2px solid rgba(255, 255, 255, 0.7);
-            border-radius: 50%;
-            left: 45px;
-            top: 45px;
-            transition: none;
-        }
-        
-        #action-buttons {
-            position: absolute;
-            right: 30px;
-            bottom: 30px;
-            pointer-events: auto;
-        }
-        
-        #enter-car-btn {
-            bottom: 70px;
-            right: 30px;
-        }
-        
-        #shoot-btn {
-            bottom: 0;
-            right: 100px;
-        }
-        
-        #loading-screen {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: #1a1a1a;
+
+        .scene-content {
+            position: relative;
+            z-index: 1;
             display: flex;
             flex-direction: column;
-            justify-content: center;
-            align-items: center;
-            z-index: 2000;
-            color: white;
-            font-family: 'Courier New', monospace;
+            gap: 20px;
         }
-        
-        #loading-text {
-            font-size: 24px;
-            margin-bottom: 20px;
+
+        .scene-label {
             text-transform: uppercase;
-            letter-spacing: 2px;
+            letter-spacing: 0.2em;
+            font-size: 10px;
+            color: var(--muted);
         }
-        
-        #loading-bar {
-            width: 300px;
-            height: 20px;
-            background: #333;
-            border: 2px solid #666;
+
+        .scene-title {
+            font-size: clamp(20px, 4vw, 32px);
+            font-weight: 700;
         }
-        
-        #loading-progress {
+
+        .dialogue {
+            font-size: clamp(16px, 3vw, 20px);
+            line-height: 1.6;
+            min-height: 120px;
+            white-space: pre-line;
+        }
+
+        .choices {
+            display: grid;
+            gap: 12px;
+        }
+
+        .choice-btn {
+            padding: 14px 18px;
+            border-radius: 16px;
+            border: 1px solid transparent;
+            background: rgba(255, 255, 255, 0.1);
+            color: var(--text);
+            font-size: 15px;
+            cursor: pointer;
+            text-align: left;
+            transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease;
+        }
+
+        .choice-btn:hover,
+        .choice-btn:focus {
+            transform: translateY(-2px);
+            border-color: rgba(255, 255, 255, 0.3);
+            background: rgba(255, 255, 255, 0.18);
+        }
+
+        .choice-btn:active {
+            transform: translateY(0);
+        }
+
+        .sidebar {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .panel {
+            background: rgba(14, 12, 26, 0.8);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 20px;
+            padding: 16px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        .panel h3 {
+            font-size: 14px;
+            text-transform: uppercase;
+            letter-spacing: 0.2em;
+            color: var(--muted);
+        }
+
+        .stat {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 14px;
+        }
+
+        .stat-bar {
+            height: 8px;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.1);
+            overflow: hidden;
+            margin-top: 6px;
+        }
+
+        .stat-bar span {
+            display: block;
             height: 100%;
-            background: linear-gradient(90deg, #ff0000, #ffff00);
-            width: 0%;
-            transition: width 0.3s;
+            border-radius: 999px;
+            background: linear-gradient(90deg, var(--accent), var(--accent-2));
         }
-        
-        @media (max-width: 768px) {
-            #mobile-controls {
-                display: block;
+
+        .inventory {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+        }
+
+        .tag {
+            font-size: 12px;
+            padding: 6px 10px;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.1);
+        }
+
+        footer {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            justify-content: space-between;
+            align-items: center;
+            padding: 18px clamp(16px, 4vw, 40px) 26px;
+            color: var(--muted);
+            font-size: 12px;
+        }
+
+        .footer-actions {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+        }
+
+        .ghost-btn {
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            background: transparent;
+            color: var(--text);
+            padding: 8px 14px;
+            border-radius: 12px;
+            font-size: 13px;
+            cursor: pointer;
+        }
+
+        .ghost-btn:hover {
+            border-color: rgba(255, 255, 255, 0.5);
+        }
+
+        .typewriter {
+            border-right: 2px solid rgba(255, 255, 255, 0.6);
+            animation: caret 0.8s step-end infinite;
+        }
+
+        @keyframes caret {
+            50% {
+                border-color: transparent;
+            }
+        }
+
+        .overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(8, 8, 16, 0.82);
+            backdrop-filter: blur(10px);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+            z-index: 20;
+        }
+
+        .overlay.active {
+            display: flex;
+        }
+
+        .modal {
+            max-width: 520px;
+            width: 100%;
+            background: #141428;
+            border-radius: 24px;
+            padding: 24px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .modal input {
+            padding: 12px 16px;
+            border-radius: 12px;
+            border: 1px solid rgba(255, 255, 255, 0.2);
+            background: rgba(255, 255, 255, 0.05);
+            color: var(--text);
+            font-size: 15px;
+        }
+
+        .modal button {
+            padding: 12px 16px;
+            border-radius: 12px;
+            border: none;
+            background: var(--accent);
+            color: #150b1f;
+            font-weight: 600;
+            cursor: pointer;
+        }
+
+        @media (max-width: 960px) {
+            main {
+                grid-template-columns: 1fr;
+            }
+        }
+
+        @media (max-width: 600px) {
+            header {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 12px;
+            }
+
+            .status-panel {
+                justify-content: flex-start;
+            }
+
+            .dialogue {
+                min-height: 160px;
+            }
+
+            .choice-btn {
+                font-size: 14px;
             }
         }
     </style>
 </head>
 <body>
-    <div id="loading-screen">
-        <div id="loading-text">Loading City Chaos...</div>
-        <div id="loading-bar">
-            <div id="loading-progress"></div>
+    <div class="app">
+        <header>
+            <div>
+                <div class="title">Тихие встречи</div>
+                <div class="subtitle">Интерактивная новелла о мягком поиске близости</div>
+            </div>
+            <div class="status-panel">
+                <div class="pill">Глава: <strong id="chapter">Пролог</strong></div>
+                <div class="pill">Настроение: <strong id="mood">Теплое</strong></div>
+                <div class="pill">Время: <strong id="time">Вечер</strong></div>
+            </div>
+        </header>
+
+        <main>
+            <section class="scene">
+                <div class="scene-content">
+                    <div class="scene-label" id="scene-label">Сцена</div>
+                    <div class="scene-title" id="scene-title">Добро пожаловать</div>
+                    <div class="dialogue" id="dialogue"></div>
+                    <div class="choices" id="choices"></div>
+                </div>
+            </section>
+
+            <aside class="sidebar">
+                <div class="panel">
+                    <h3>Профиль</h3>
+                    <div class="stat">
+                        <span>Имя героя</span>
+                        <strong id="player-name">—</strong>
+                    </div>
+                    <div class="stat">
+                        <span>Уверенность</span>
+                        <strong id="confidence">50</strong>
+                    </div>
+                    <div class="stat-bar"><span id="confidence-bar" style="width:50%"></span></div>
+                    <div class="stat">
+                        <span>Искренность</span>
+                        <strong id="sincerity">50</strong>
+                    </div>
+                    <div class="stat-bar"><span id="sincerity-bar" style="width:50%"></span></div>
+                    <div class="stat">
+                        <span>Симпатия</span>
+                        <strong id="affection">50</strong>
+                    </div>
+                    <div class="stat-bar"><span id="affection-bar" style="width:50%"></span></div>
+                </div>
+
+                <div class="panel">
+                    <h3>Заметки</h3>
+                    <div class="inventory" id="notes"></div>
+                </div>
+
+                <div class="panel">
+                    <h3>Подсказка</h3>
+                    <p id="hint" style="font-size: 13px; line-height: 1.5; color: var(--muted);"></p>
+                </div>
+            </aside>
+        </main>
+
+        <footer>
+            <div>Выбирай ответы и наблюдай за тем, как меняется история.</div>
+            <div class="footer-actions">
+                <button class="ghost-btn" id="save-btn">Сохранить</button>
+                <button class="ghost-btn" id="restart-btn">Начать заново</button>
+            </div>
+        </footer>
+    </div>
+
+    <div class="overlay" id="intro-overlay">
+        <div class="modal">
+            <h2>Перед началом</h2>
+            <p>Это камерная история без фотографий и видео. Ты создаешь атмосферу словами и выбором. Как зовут героя?</p>
+            <input type="text" id="name-input" maxlength="20" placeholder="Например, Артём">
+            <button id="start-btn">Начать историю</button>
         </div>
     </div>
-    
-    <div id="game-container">
-        <canvas id="game-canvas"></canvas>
-        
-        <div id="mobile-controls">
-            <div id="joystick-container">
-                <div id="joystick-base"></div>
-                <div id="joystick-stick"></div>
-            </div>
-            
-            <div id="action-buttons">
-                <div class="control-button" id="enter-car-btn">🚗</div>
-                <div class="control-button" id="shoot-btn">🔫</div>
-            </div>
-        </div>
-    </div>
-    
-    <script src="https://cdn.jsdelivr.net/npm/phaser@3.70.0/dist/phaser.min.js"></script>
+
     <script type="module" src="js/game.js"></script>
 </body>
 </html>

--- a/js/game.js
+++ b/js/game.js
@@ -1,47 +1,531 @@
-// Game configuration and main entry point
-import { GameScene } from './scenes/GameScene.js';
-import { PreloadScene } from './scenes/PreloadScene.js';
-import { MobileControls } from './controls/MobileControls.js';
-
-// Game configuration
-const config = {
-    type: Phaser.AUTO,
-    parent: 'game-container',
-    canvas: document.getElementById('game-canvas'),
-    width: 1280,
-    height: 720,
-    backgroundColor: '#2a2a2a',
-    physics: {
-        default: 'arcade',
-        arcade: {
-            gravity: { y: 0 },
-            debug: false
-        }
-    },
-    scale: {
-        mode: Phaser.Scale.FIT,
-        autoCenter: Phaser.Scale.CENTER_BOTH,
-        width: 1280,
-        height: 720
-    },
-    scene: [PreloadScene, GameScene]
+const elements = {
+    chapter: document.getElementById('chapter'),
+    mood: document.getElementById('mood'),
+    time: document.getElementById('time'),
+    sceneLabel: document.getElementById('scene-label'),
+    sceneTitle: document.getElementById('scene-title'),
+    dialogue: document.getElementById('dialogue'),
+    choices: document.getElementById('choices'),
+    playerName: document.getElementById('player-name'),
+    confidence: document.getElementById('confidence'),
+    sincerity: document.getElementById('sincerity'),
+    affection: document.getElementById('affection'),
+    confidenceBar: document.getElementById('confidence-bar'),
+    sincerityBar: document.getElementById('sincerity-bar'),
+    affectionBar: document.getElementById('affection-bar'),
+    notes: document.getElementById('notes'),
+    hint: document.getElementById('hint'),
+    introOverlay: document.getElementById('intro-overlay'),
+    nameInput: document.getElementById('name-input'),
+    startBtn: document.getElementById('start-btn'),
+    saveBtn: document.getElementById('save-btn'),
+    restartBtn: document.getElementById('restart-btn')
 };
 
-// Initialize game
-const game = new Phaser.Game(config);
+const defaultState = {
+    playerName: 'Гость',
+    confidence: 50,
+    sincerity: 50,
+    affection: 50,
+    notes: [],
+    sceneId: 'intro',
+    flags: {
+        likesPoetry: false,
+        prefersQuiet: false,
+        sharedStory: false
+    }
+};
 
-// Initialize mobile controls
-const mobileControls = new MobileControls();
+let state = structuredClone(defaultState);
+let typewriterTimer = null;
 
-// Make mobile controls available globally
-window.mobileControls = mobileControls;
+const scenes = {
+    intro: {
+        chapter: 'Пролог',
+        mood: 'Теплое',
+        time: 'Вечер',
+        label: 'Городской свет',
+        title: 'Тихая кофейня на углу',
+        text: ({ playerName }) => `${playerName} решает искать близость без спешки. Вечером ты заходишь в небольшую кофейню, где пахнет карамелью и дождём. За стойкой девушка поправляет книгу и улыбается.
 
-// Hide loading screen when game is ready
-window.addEventListener('load', () => {
-    setTimeout(() => {
-        const loadingScreen = document.getElementById('loading-screen');
-        if (loadingScreen) {
-            loadingScreen.style.display = 'none';
+«Привет. Ты здесь впервые?»`,
+        hint: 'Попробуй выбрать тон, который отражает твой стиль общения. Он влияет на симпатию и уверенность.',
+        choices: [
+            {
+                text: '«Привет. Здесь очень спокойно. Можно присесть рядом?»',
+                next: 'gentle',
+                effects: { affection: 8, sincerity: 6 }
+            },
+            {
+                text: '«Да, я искал место, где можно подумать. Как тебя зовут?»',
+                next: 'direct',
+                effects: { confidence: 6, affection: 4 }
+            },
+            {
+                text: '«Привет. Я принёс с собой список любимых мест. Это место — новое открытие.»',
+                next: 'playful',
+                effects: { confidence: 4, sincerity: 3 }
+            }
+        ]
+    },
+    gentle: {
+        chapter: 'Глава 1',
+        mood: 'Нежное',
+        time: 'Вечер',
+        label: 'Первый диалог',
+        title: 'Разговор у окна',
+        text: () => `Она кивает и отодвигает чашку. «Меня зовут Лада. Люблю, когда люди сразу говорят, что им важно». За окном тихий дождь.`,
+        hint: 'Слушай и задавай вопросы. Это повышает искренность.',
+        choices: [
+            {
+                text: 'Спросить о её книге и почему она здесь.',
+                next: 'book',
+                effects: { sincerity: 8, affection: 5 }
+            },
+            {
+                text: 'Поделиться, что тебе хочется найти отношения без давления.',
+                next: 'honest',
+                effects: { sincerity: 10, confidence: 4 }
+            },
+            {
+                text: 'Предложить прогуляться после кофе.',
+                next: 'walk',
+                effects: { confidence: 6 }
+            }
+        ]
+    },
+    direct: {
+        chapter: 'Глава 1',
+        mood: 'Интригующее',
+        time: 'Вечер',
+        label: 'Поворот',
+        title: 'Смелое знакомство',
+        text: () => `«Я Лада», — улыбается она и сразу смотрит в глаза. «Редко встречаю людей, которые прямо спрашивают».`,
+        hint: 'Смелость добавляет уверенности, но важно бережно оставаться искренним.',
+        choices: [
+            {
+                text: 'Сказать, что ценишь честность и хочешь узнать её лучше.',
+                next: 'honest',
+                effects: { sincerity: 6, affection: 4 }
+            },
+            {
+                text: 'Пошутить про то, что ты "профессиональный слушатель".',
+                next: 'playful',
+                effects: { confidence: 6 }
+            },
+            {
+                text: 'Предложить выбрать музыку для атмосферы.',
+                next: 'music',
+                effects: { affection: 5 }
+            }
+        ]
+    },
+    playful: {
+        chapter: 'Глава 1',
+        mood: 'Лёгкое',
+        time: 'Вечер',
+        label: 'Лёгкий флирт',
+        title: 'Список любимых мест',
+        text: () => `Лада смеётся: «Список? Это неожиданно». Она наклоняется ближе, будто хочет заглянуть в твой блокнот.`,
+        hint: 'Лёгкость хорошо работает, если подпитывать её вниманием к собеседнице.',
+        choices: [
+            {
+                text: 'Показать список и предложить добавить её любимые места.',
+                next: 'book',
+                effects: { affection: 6, sincerity: 5 }
+            },
+            {
+                text: 'Спросить, что для неё важнее — тишина или музыка.',
+                next: 'music',
+                effects: { sincerity: 4 }
+            },
+            {
+                text: 'Открыто сказать, что хотел бы познакомиться ближе.',
+                next: 'honest',
+                effects: { confidence: 5, affection: 3 }
+            }
+        ]
+    },
+    book: {
+        chapter: 'Глава 2',
+        mood: 'Теплое',
+        time: 'Поздний вечер',
+        label: 'Общие темы',
+        title: 'Литературная пауза',
+        text: () => `Она рассказывает, что записывает короткие истории о людях в кафе. «Я люблю ловить момент, когда люди чуть доверяют друг другу».`,
+        hint: 'Тонкие вопросы повышают симпатию. Можно поделиться личным опытом.',
+        choices: [
+            {
+                text: 'Признаться, что ты тоже записываешь мысли, когда волнуешься.',
+                next: 'shared',
+                effects: { sincerity: 9, affection: 7, flags: { sharedStory: true } }
+            },
+            {
+                text: 'Сказать, что любишь поэзию и предлагаешь обменяться цитатами.',
+                next: 'poetry',
+                effects: { affection: 8, flags: { likesPoetry: true } }
+            },
+            {
+                text: 'Предложить выйти на улицу и посмотреть на дождь.',
+                next: 'walk',
+                effects: { confidence: 5 }
+            }
+        ]
+    },
+    music: {
+        chapter: 'Глава 2',
+        mood: 'Спокойное',
+        time: 'Поздний вечер',
+        label: 'Ритм',
+        title: 'Музыка в наушниках',
+        text: () => `Лада достаёт наушники. «Когда хочется подумать, я ставлю что-то инструментальное». Она протягивает один наушник.`,
+        hint: 'Совместный ритуал создаёт близость. Это повышает симпатию.',
+        choices: [
+            {
+                text: 'Согласиться и описать, какие чувства вызывает музыка.',
+                next: 'shared',
+                effects: { affection: 7, sincerity: 4 }
+            },
+            {
+                text: 'Сказать, что тебе ближе тишина, но ты хочешь понять её.',
+                next: 'quiet',
+                effects: { sincerity: 6, flags: { prefersQuiet: true } }
+            },
+            {
+                text: 'Вежливо отказаться и предложить позже вместе выбрать плейлист.',
+                next: 'walk',
+                effects: { confidence: 4 }
+            }
+        ]
+    },
+    honest: {
+        chapter: 'Глава 2',
+        mood: 'Искреннее',
+        time: 'Поздний вечер',
+        label: 'Открытость',
+        title: 'Разговор без масок',
+        text: ({ playerName }) => `«Я понимаю», — говорит Лада. «Иногда хочется, чтобы тебя видели без ожиданий». Она задерживает взгляд на ${playerName} чуть дольше.`,
+        hint: 'Искренность повышает симпатию, но не забывай о лёгкости.',
+        choices: [
+            {
+                text: 'Спросить, что ей важно в отношениях.',
+                next: 'shared',
+                effects: { sincerity: 6, affection: 6 }
+            },
+            {
+                text: 'Рассказать о своём идеальном первом свидании.',
+                next: 'dream',
+                effects: { confidence: 4, affection: 4 }
+            },
+            {
+                text: 'Предложить перенести разговор на прогулку.',
+                next: 'walk',
+                effects: { confidence: 5 }
+            }
+        ]
+    },
+    quiet: {
+        chapter: 'Глава 3',
+        mood: 'Созерцательное',
+        time: 'Ночь',
+        label: 'Тихий ритуал',
+        title: 'Вкус молчания',
+        text: () => `Вы сидите молча и слушаете, как капли стучат по стеклу. Лада улыбается: «С тобой не надо заполнять паузу».`,
+        hint: 'Иногда молчание говорит больше. Добавь заметку, чтобы запомнить момент.',
+        notes: ['Общая тишина'],
+        choices: [
+            {
+                text: 'Сказать, что тебе нравится эта тишина.',
+                next: 'final',
+                effects: { affection: 8 }
+            },
+            {
+                text: 'Предложить обменяться номерами, чтобы продолжить общение.',
+                next: 'final',
+                effects: { confidence: 6 }
+            }
+        ]
+    },
+    shared: {
+        chapter: 'Глава 3',
+        mood: 'Доверительное',
+        time: 'Ночь',
+        label: 'Общие истории',
+        title: 'Сблизиться через слова',
+        text: () => `Лада делится историей о том, как однажды почувствовала себя услышанной. Ты замечаешь, как вам легче дышать рядом.`,
+        hint: 'Отмечай общие ценности. Они усилят симпатию.',
+        notes: ['Важна честность', 'Любит истории'],
+        choices: [
+            {
+                text: 'Сказать, что хочешь продолжить знакомство и назначить встречу.',
+                next: 'final',
+                effects: { affection: 6, confidence: 4 }
+            },
+            {
+                text: 'Предложить обменяться заметками и написать друг другу завтра.',
+                next: 'final',
+                effects: { sincerity: 6 }
+            }
+        ]
+    },
+    poetry: {
+        chapter: 'Глава 3',
+        mood: 'Поэтичное',
+        time: 'Ночь',
+        label: 'Слова и чувства',
+        title: 'Обмен цитатами',
+        text: () => `Она записывает строку: «Тепло — это когда тебя слушают до конца». «Это про сегодня», — улыбается она.`,
+        hint: 'Поэзия усиливает романтичность. Поддержи этот настрой.',
+        notes: ['Любит поэзию'],
+        choices: [
+            {
+                text: 'Ответить своей строкой и поблагодарить её.',
+                next: 'final',
+                effects: { affection: 8, sincerity: 4 }
+            },
+            {
+                text: 'Предложить устроить совместный вечер чтения.',
+                next: 'final',
+                effects: { confidence: 5 }
+            }
+        ]
+    },
+    dream: {
+        chapter: 'Глава 3',
+        mood: 'Мечтательное',
+        time: 'Ночь',
+        label: 'Идеи',
+        title: 'Образ будущего',
+        text: () => `Ты описываешь мягкое свидание: прогулка, музыка, спокойный разговор. Лада кивает: «Это похоже на меня».`,
+        hint: 'Совпадение мечт добавляет симпатию.',
+        notes: ['Общие мечты'],
+        choices: [
+            {
+                text: 'Предложить воплотить это уже на выходных.',
+                next: 'final',
+                effects: { affection: 6, confidence: 4 }
+            },
+            {
+                text: 'Спросить, что бы она добавила к этой картине.',
+                next: 'final',
+                effects: { sincerity: 5 }
+            }
+        ]
+    },
+    walk: {
+        chapter: 'Глава 3',
+        mood: 'Свежесть',
+        time: 'Ночь',
+        label: 'Прогулка',
+        title: 'Дождевые огни',
+        text: () => `Вы выходите в прохладный воздух. Город светится отражениями. Лада идёт рядом и спрашивает: «Ты часто так знакомишься?»`,
+        hint: 'Подчеркни, что тебе важна искренность. Это добавит доверия.',
+        notes: ['Дождь как символ начала'],
+        choices: [
+            {
+                text: 'Сказать, что ты выбираешь редкие, но важные встречи.',
+                next: 'final',
+                effects: { sincerity: 7 }
+            },
+            {
+                text: 'Пошутить, что сегодня всё сложилось идеально.',
+                next: 'final',
+                effects: { affection: 5, confidence: 3 }
+            }
+        ]
+    },
+    final: {
+        chapter: 'Финал',
+        mood: 'Светлое',
+        time: 'Ночь',
+        label: 'Новая глава',
+        title: 'Точка согласия',
+        text: ({ playerName, affection, sincerity, confidence, flags }) => {
+            const score = affection + sincerity + confidence;
+            const tone = score > 190 ? 'очень тепло' : score > 160 ? 'надёжно' : 'мягко';
+            const bonus = flags.likesPoetry
+                ? ' Она обещает прислать тебе подборку стихов.'
+                : flags.prefersQuiet
+                    ? ' Она говорит, что ей нравится твоя спокойная энергия.'
+                    : flags.sharedStory
+                        ? ' Вы решаете обменяться заметками и продолжить общение.'
+                        : ' Вы улыбаетесь и понимаете, что вечер удался.';
+            return `${playerName}, вы завершаете вечер ${tone}. Лада соглашается на продолжение общения.${bonus}\n\nИстория может продолжиться, когда ты будешь готов.`;
+        },
+        hint: 'Сохрани этот момент и начни заново, чтобы открыть другие варианты.',
+        choices: [
+            {
+                text: 'Сохранить и остаться в этом финале.',
+                next: 'final',
+                effects: {}
+            },
+            {
+                text: 'Начать новую историю с другим настроем.',
+                next: 'intro',
+                effects: { reset: true }
+            }
+        ]
+    }
+};
+
+const typeText = (text) => {
+    clearTimeout(typewriterTimer);
+    elements.dialogue.textContent = '';
+    elements.dialogue.classList.add('typewriter');
+    let index = 0;
+
+    const step = () => {
+        elements.dialogue.textContent = text.slice(0, index);
+        index += 1;
+        if (index <= text.length) {
+            typewriterTimer = setTimeout(step, 18);
+        } else {
+            elements.dialogue.classList.remove('typewriter');
         }
-    }, 1000);
-});
+    };
+
+    step();
+};
+
+const updateStats = () => {
+    elements.playerName.textContent = state.playerName;
+    elements.confidence.textContent = state.confidence;
+    elements.sincerity.textContent = state.sincerity;
+    elements.affection.textContent = state.affection;
+    elements.confidenceBar.style.width = `${state.confidence}%`;
+    elements.sincerityBar.style.width = `${state.sincerity}%`;
+    elements.affectionBar.style.width = `${state.affection}%`;
+};
+
+const updateNotes = () => {
+    elements.notes.innerHTML = '';
+    if (state.notes.length === 0) {
+        const empty = document.createElement('span');
+        empty.className = 'tag';
+        empty.textContent = 'Пока пусто';
+        elements.notes.appendChild(empty);
+        return;
+    }
+
+    state.notes.forEach((note) => {
+        const tag = document.createElement('span');
+        tag.className = 'tag';
+        tag.textContent = note;
+        elements.notes.appendChild(tag);
+    });
+};
+
+const clampStats = () => {
+    state.confidence = Math.min(100, Math.max(0, state.confidence));
+    state.sincerity = Math.min(100, Math.max(0, state.sincerity));
+    state.affection = Math.min(100, Math.max(0, state.affection));
+};
+
+const applyEffects = (effects = {}) => {
+    if (effects.reset) {
+        state = structuredClone({ ...defaultState, playerName: state.playerName });
+        return;
+    }
+
+    state.confidence += effects.confidence ?? 0;
+    state.sincerity += effects.sincerity ?? 0;
+    state.affection += effects.affection ?? 0;
+
+    if (effects.flags) {
+        state.flags = { ...state.flags, ...effects.flags };
+    }
+
+    clampStats();
+};
+
+const renderScene = (sceneId) => {
+    const scene = scenes[sceneId];
+    if (!scene) return;
+
+    state.sceneId = sceneId;
+    elements.chapter.textContent = scene.chapter;
+    elements.mood.textContent = scene.mood;
+    elements.time.textContent = scene.time;
+    elements.sceneLabel.textContent = scene.label;
+    elements.sceneTitle.textContent = scene.title;
+    elements.hint.textContent = scene.hint;
+
+    if (scene.notes) {
+        scene.notes.forEach((note) => {
+            if (!state.notes.includes(note)) {
+                state.notes.push(note);
+            }
+        });
+    }
+
+    const dialogueText = typeof scene.text === 'function' ? scene.text(state) : scene.text;
+    typeText(dialogueText);
+
+    elements.choices.innerHTML = '';
+    scene.choices.forEach((choice) => {
+        const button = document.createElement('button');
+        button.className = 'choice-btn';
+        button.textContent = choice.text;
+        button.addEventListener('click', () => {
+            applyEffects(choice.effects);
+            updateStats();
+            updateNotes();
+            renderScene(choice.next);
+        });
+        elements.choices.appendChild(button);
+    });
+};
+
+const saveGame = () => {
+    localStorage.setItem('quiet-novel-state', JSON.stringify(state));
+};
+
+const loadGame = () => {
+    const saved = localStorage.getItem('quiet-novel-state');
+    if (saved) {
+        state = { ...state, ...JSON.parse(saved) };
+    }
+};
+
+const startGame = () => {
+    elements.introOverlay.classList.remove('active');
+    updateStats();
+    updateNotes();
+    renderScene(state.sceneId);
+};
+
+const init = () => {
+    loadGame();
+    elements.introOverlay.classList.add('active');
+    elements.nameInput.value = state.playerName === 'Гость' ? '' : state.playerName;
+
+    elements.startBtn.addEventListener('click', () => {
+        const name = elements.nameInput.value.trim();
+        state.playerName = name.length ? name : 'Гость';
+        updateStats();
+        saveGame();
+        startGame();
+    });
+
+    elements.saveBtn.addEventListener('click', () => {
+        saveGame();
+        elements.saveBtn.textContent = 'Сохранено!';
+        setTimeout(() => {
+            elements.saveBtn.textContent = 'Сохранить';
+        }, 1200);
+    });
+
+    elements.restartBtn.addEventListener('click', () => {
+        state = structuredClone(defaultState);
+        state.playerName = 'Гость';
+        localStorage.removeItem('quiet-novel-state');
+        elements.nameInput.value = '';
+        elements.introOverlay.classList.add('active');
+    });
+
+    if (state.playerName !== 'Гость') {
+        startGame();
+    }
+};
+
+init();


### PR DESCRIPTION
### Motivation

- Replace the previous top-down Phaser page with a compact, mobile-first single-page visual novel experience. 
- Provide a private, text-only interactive story flow (no photos or video) with clear UI for phone screens. 
- Track player state, choices and simple stats so the narrative can branch and persist between sessions.

### Description

- Replace `index.html` layout and styles with a responsive visual-novel UI including header, scene panel, choices, sidebar stats/notes, and an intro overlay for the player name. 
- Replace the previous `js/game.js` (Phaser bootstrap) with a plain JS narrative engine that defines `scenes` (branching nodes), renders choices, runs a typewriter for dialogue, and updates UI elements. 
- Add client-side state management: `defaultState`, `state` cloning, `applyEffects`, `clampStats`, `saveGame` and `loadGame` using `localStorage`, plus `save` and `restart` controls. 
- Improve mobile accessibility and UX with CSS variables, adaptive layout, and small UI interactions like temporary save feedback.

### Testing

- Served the app locally with `python3 -m http.server 8000` and confirmed the server started successfully. 
- Ran an automated browser script that loaded `http://127.0.0.1:8000` and produced a page screenshot at `artifacts/quiet-novel.png`, which verifies the intro overlay and UI render (after earlier timeouts during retries, the final run succeeded). 
- No automated unit tests were added for the JS logic; verification was performed via the end-to-end page load and screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971a218774c83319654b074463c2787)